### PR TITLE
fix(type): type reference problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
   "unpkg": "dist/vue-jsx-runtime.iife.prod.js",
   "jsdelivr": "dist/vue-jsx-runtime.iife.prod.js",
   "types": "dist/vue-jsx-runtime.d.ts",
+  "typesVersions": {
+    "*": {
+      "jsx-runtime": ["./dist/vue-jsx-runtime.d.ts"],
+      "jsx-dev-runtime": ["./dist/vue-jsx-runtime.d.ts"]
+    }
+  },
   "exports": {
     ".": {
       "browser": "./dist/vue-jsx-runtime.esm-browser.js",


### PR DESCRIPTION
```text
Could not find a declaration file for module 'vue-jsx-runtime/jsx-runtime'. '/Users/yingpengsha/Desktop/code/multi-jsx-project/node_modules/.pnpm/vue-jsx-runtime@0.1.0_vue@3.2.45/node_modules/vue-jsx-runtime/jsx-runtime.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/vue-jsx-runtime` if it exists or add a new declaration (.d.ts) file containing `declare module 'vue-jsx-runtime/jsx-runtime';`ts(7016)
```
![image](https://user-images.githubusercontent.com/37143265/205260892-05c4aef5-1c3f-459a-a3d7-2564b1654fb2.png)
